### PR TITLE
Node mover fix

### DIFF
--- a/src/uk/ac/ebi/vfb/neo4j/flybase2neo/add_refs_for_anat.py
+++ b/src/uk/ac/ebi/vfb/neo4j/flybase2neo/add_refs_for_anat.py
@@ -34,21 +34,6 @@ supported_xrefs = {'FlyBase': 'FlyBase:FBrf\d{7}',
 
 
 
-def get_dbxrefs(oboXrefs):
-    out = []
-    for xref in oboXrefs:
-        out[xref['id']] = out[xref['database']]
-    return out
-
-
-def get_def_dbxrefs():
-
-    return
-
-def get_syn_dbxrefs():
-    return
-
-
 # obo_synonym:{"name":"IDFP",
 #              "scope":"hasBroadSynonym",
 #               "type":null,"xrefs":[
@@ -57,28 +42,28 @@ def get_syn_dbxrefs():
 # ,{"name":"vmpr","scope":"hasRelatedSynonym","type":null,"xrefs":[{"database":"FlyBase","id":"FBrf0193607","description":null,"url":null}]},{"name":"LAL","scope":"hasExactSynonym","type":"BrainName official abbreviation","xrefs":[{"database":"FlyBase","id":"FBrf0224194","description":null,"url":null}]}
 
 
-def proc_xrefs(dbxrefs):
-    if not dbxrefs:
-        return False
-    out = {}
-    for db in supported_xrefs.keys():
-        out[db] = []
-    for xref in dbxrefs:
-        for db, re_string in supported_xrefs.items():
-            m = re.compile(re_string)
-            if re.match(m, xref):
-                ref = xref.split(':')[1]
-                out[db].append(ref)
-    return out
+# def proc_xrefs(dbxrefs):
+#     if not dbxrefs:
+#         return False
+#     out = {}
+#     for db in supported_xrefs.keys():
+#         out[db] = []
+#     for xref in dbxrefs:
+#         for db, re_string in supported_xrefs.items():
+#             m = re.compile(re_string)
+#             if re.match(m, xref):
+#                 ref = xref.split(':')[1]
+#                 out[db].append(ref)
+#     return out
 
 
 def roll_cypher_add_def_pub_link(sfid, pub_id_typ, pub_id):
     """Generates a Cypher statement that links an existing class
     to a pub node with the specified attribute.  Generates a new pub node
      if none exists."""
-    return  "MATCH (a:Class { short_form : '%s' }) " \
-            "MERGE (p:pub:Individual { %s : '%s' }) " \
-            "MERGE (a)-[:has_reference { typ : 'def' }]->(p)"  % (sfid, pub_id_typ, pub_id)
+    return "MATCH (a:Class { short_form : '%s' }) " \
+           "MERGE (p:pub:Individual { %s : '%s' }) " \
+           "MERGE (a)-[:has_reference { typ : 'def' }]->(p)" % (sfid, pub_id_typ, pub_id)
 
 
 def roll_cypher_add_syn_pub_link(sfid, s, pub_id_typ, pub_id):
@@ -92,17 +77,31 @@ def roll_cypher_add_syn_pub_link(sfid, s, pub_id_typ, pub_id):
 
 
 nc.commit_list(["MERGE (:pub:Individual { FlyBase: 'Unattributed' })"])
-q = nc.commit_list(["MATCH (c:Class) return short_form, c.obo_synonym as syns, c.obo_definition_citation as def"])
+q = nc.commit_list(["MATCH (c:Class|Individual) return short_form, c.obo_synonym as syns, c.obo_definition_citation as def"])
 dc = results_2_dict_list(q)
-s = []
+statements = []
 for d in dc:
     if d['def']:
         def_cit = json.loads(d['def'])
-        s.append[roll_cypher_add_def_pub_link(
+        statements.append(roll_cypher_add_def_pub_link(
             sfid = d['short_form'],
-            pub_id = d[],
-            typ = 'def',
-            )]
+            pub_id = d['id'],
+            pub_id_typ = 'def',
+            ))
+    elif d['syns']:
+        for syn in d['syns']:
+            s = json.loads(syn)
+            statements.append(
+                roll_cypher_add_syn_pub_link(
+                    sfid = d['short_form'],
+                    pub_id = d['id'],
+                    pub_id_typ = ['database'],
+                    s=s))
+
+nc.commit_list_in_chunks(statements, verbose=True, chunk_length=2000)
+
+
+
 
 
 
@@ -115,4 +114,3 @@ obo_synonym_string = '[{"name":"IDFP","scope":"hasBroadSynonym","type":null,"xre
 obo_synonym = json.loads(obo_synonym)
 obo_definition_citation_string = '{"definition":"A sense organ embedded in the integument and consisting of one or a cluster of sensory neurons and associated sensory structures, support cells and glial cells forming a single organized unit with a largely bona fide boundary.","oboXrefs":[{"database":"FlyBase","id":"FBrf0111704","description":null,"url":null}]}'
 obo_definition_citation = json.load(obo_definition_citation_string)
-nc.commit_list_in_chunks(statements, verbose= True, chunk_length = chunk_length)

--- a/src/uk/ac/ebi/vfb/neo4j/flybase2neo/add_refs_for_anat.py
+++ b/src/uk/ac/ebi/vfb/neo4j/flybase2neo/add_refs_for_anat.py
@@ -1,0 +1,118 @@
+from ..neo4j_tools import neo4j_connect, results_2_dict_list
+import sys
+import json
+import re
+
+nc = neo4j_connect(base_uri=sys.argv[1],
+                   usr=sys.argv[2],
+                   pwd=sys.argv[3])
+
+"""
+Converts references on definitions and synonyms, stored as entity attributes
+in OLS Neo4j, into edges linked to pub nodes.  In the case of synonyms, 
+edges store synonym names, scopes and types. 
+
+Background: 
+
+OLS Neo4J includes references attached to definitions and synonyms, 
+but these are packed into JSON strings on attributes.
+
+Almost every reference has an FBrf, but a few only have PMIDS or DOIs. 
+Merge strategy uses FBrf first, then PMID, then DOI."""
+
+
+
+supported_xrefs = {'FlyBase': 'FlyBase:FBrf\d{7}',
+                   'PMID': 'PMID:\d+',
+                   'DOI': 'DOI:.+', 'http': 'http:.+'}
+
+
+# obo_definition_citation:{"definition":"Any sense organ (FBbt:00005155) that is part of some adult (FBbt:00003004).",
+# "oboXrefs":[{"database":"FlyBase","id":"FBrf0031004","description":null,"url":null},
+# {"database":"FlyBase","id":"FBrf0007734","description":null,"url":null},
+# {"database":"FBC","id":"auto_generated_definition","description":null,"url":null}]}
+
+
+
+def get_dbxrefs(oboXrefs):
+    out = []
+    for xref in oboXrefs:
+        out[xref['id']] = out[xref['database']]
+    return out
+
+
+def get_def_dbxrefs():
+
+    return
+
+def get_syn_dbxrefs():
+    return
+
+
+# obo_synonym:{"name":"IDFP",
+#              "scope":"hasBroadSynonym",
+#               "type":null,"xrefs":[
+#               {"database":"FlyBase","id":"FBrf0212704",
+#               "description":null,"url":null}]}
+# ,{"name":"vmpr","scope":"hasRelatedSynonym","type":null,"xrefs":[{"database":"FlyBase","id":"FBrf0193607","description":null,"url":null}]},{"name":"LAL","scope":"hasExactSynonym","type":"BrainName official abbreviation","xrefs":[{"database":"FlyBase","id":"FBrf0224194","description":null,"url":null}]}
+
+
+def proc_xrefs(dbxrefs):
+    if not dbxrefs:
+        return False
+    out = {}
+    for db in supported_xrefs.keys():
+        out[db] = []
+    for xref in dbxrefs:
+        for db, re_string in supported_xrefs.items():
+            m = re.compile(re_string)
+            if re.match(m, xref):
+                ref = xref.split(':')[1]
+                out[db].append(ref)
+    return out
+
+
+def roll_cypher_add_def_pub_link(sfid, pub_id_typ, pub_id):
+    """Generates a Cypher statement that links an existing class
+    to a pub node with the specified attribute.  Generates a new pub node
+     if none exists."""
+    return  "MATCH (a:Class { short_form : '%s' }) " \
+            "MERGE (p:pub:Individual { %s : '%s' }) " \
+            "MERGE (a)-[:has_reference { typ : 'def' }]->(p)"  % (sfid, pub_id_typ, pub_id)
+
+
+def roll_cypher_add_syn_pub_link(sfid, s, pub_id_typ, pub_id):
+    """Generates a Cypher statement that links an existing class
+    to a pub node ..."""
+    label = re.sub("'", "\'", s['name'])
+    return  "MATCH (a:Class { short_form : '%s' }) " \
+            "MERGE (p:pub:Individual { %s : '%s' }) " \
+            "MERGE (a)-[:has_reference { typ : 'syn', scope: '%s', synonym : \"%s\", cat: '%s' }]->(p)" \
+            "" % (sfid, pub_id_typ, pub_id, s['scope'], label, s['type'])
+
+
+nc.commit_list(["MERGE (:pub:Individual { FlyBase: 'Unattributed' })"])
+q = nc.commit_list(["MATCH (c:Class) return short_form, c.obo_synonym as syns, c.obo_definition_citation as def"])
+dc = results_2_dict_list(q)
+s = []
+for d in dc:
+    if d['def']:
+        def_cit = json.loads(d['def'])
+        s.append[roll_cypher_add_def_pub_link(
+            sfid = d['short_form'],
+            pub_id = d[],
+            typ = 'def',
+            )]
+
+
+
+# to json
+# proc to new commit statements.
+
+
+# tests
+obo_synonym_string = '[{"name":"IDFP","scope":"hasBroadSynonym","type":null,"xrefs":[{"database":"FlyBase","id":"FBrf0212704","description":null,"url":null}]},{"name":"vmpr","scope":"hasRelatedSynonym","type":null,"xrefs":[{"database":"FlyBase","id":"FBrf0193607","description":null,"url":null}]},{"name":"LAL","scope":"hasExactSynonym","type":"BrainName official abbreviation","xrefs":[{"database":"FlyBase","id":"FBrf0224194","description":null,"url":null}]}]'
+obo_synonym = json.loads(obo_synonym)
+obo_definition_citation_string = '{"definition":"A sense organ embedded in the integument and consisting of one or a cluster of sensory neurons and associated sensory structures, support cells and glial cells forming a single organized unit with a largely bona fide boundary.","oboXrefs":[{"database":"FlyBase","id":"FBrf0111704","description":null,"url":null}]}'
+obo_definition_citation = json.load(obo_definition_citation_string)
+nc.commit_list_in_chunks(statements, verbose= True, chunk_length = chunk_length)

--- a/src/uk/ac/ebi/vfb/neo4j/neo4j_tools.py
+++ b/src/uk/ac/ebi/vfb/neo4j/neo4j_tools.py
@@ -6,6 +6,7 @@ import warnings
 import re
 import time
 from datetime import datetime, timedelta
+import math
 #import token
 
 
@@ -76,7 +77,7 @@ class neo4j_connect():
         chunked_statements = chunks(l = statements, n=chunk_length)
         chunk_results = []
         i = 1
-        c_no = len(statements)/chunk_length
+        c_no = math.ceil(len(statements)/chunk_length)
         for c in chunked_statements:
             if verbose:
                 start_time = time.time()
@@ -86,14 +87,8 @@ class neo4j_connect():
             r = self.commit_list(c)
             if verbose:
                 t = time.time() - start_time
-                print("Processing took %d seconds for %s statements" % (t,len(c)))
-                print("Estimated time to completion: %s." % str(timedelta(
-                                                                                   seconds = (
-                                                                                              t*(c_no - i)
-                                                                                              )
-                                                                                   )
-                                                                )
-                      )
+                print("Processing took %d seconds for %s statements" % (t, len(c)))
+                print("Estimated time to completion: %s." % str(timedelta(seconds=(t*(c_no - i)))))
             if type(r) == list:
                 chunk_results.extend(r)
             else:

--- a/src/uk/ac/ebi/vfb/neo4j/neo4j_tools.py
+++ b/src/uk/ac/ebi/vfb/neo4j/neo4j_tools.py
@@ -291,8 +291,9 @@ class neo4jContentMover:
                 diff = from_labels - TO_label_lookup[k] # find labels that are on this node in From, not to
                 if diff:
                     lab_string = ':'+':'.join(diff)
-                    statements.add("MATCH (n) WHERE n.%s = %s"
+                    statements.add("MATCH (n) WHERE n.%s = '%s'"
                                    " SET n%s  " % (node_key, k, lab_string))
+
 
         self.To.commit_list_in_chunks(statements=list(statements),
                                       verbose=verbose,

--- a/src/uk/ac/ebi/vfb/neo4j/test/neo_tools_tests.py
+++ b/src/uk/ac/ebi/vfb/neo4j/test/neo_tools_tests.py
@@ -49,7 +49,7 @@ class TestContentMover(unittest.TestCase):
     def testMoveNodeLabels(self):
         self.ncm.To.commit_list(["CREATE (n { short_form : 'VFB_00000002' })"])
         self.ncm.move_node_labels(match="MATCH (n { short_form : 'VFB_00000002' })",
-                                  node_key='iri')
+                                  node_key='short_form')
         query = self.ncm.To.commit_list(["MATCH (n { short_form : 'VFB_00000002' })"
                                          "RETURN labels(n) as nlab"])
         query_results = results_2_dict_list(query)
@@ -57,7 +57,8 @@ class TestContentMover(unittest.TestCase):
         assert 'Individual' in query_results[0]['nlab']
 
     def tearDown(self):
-        self.ncm.To.commit_list(["MATCH (x)-[r]-(y) DETACH DELETE x,y,r"])
+        #self.ncm.To.commit_list(["MATCH (x)-[r]-(y) DELETE r", "MATCH (n) delete (n)"])
+        return
 
 
 


### PR DESCRIPTION
New version node_mover:
 - fixes error in previous version that lead to match statement lacking where clause. 
 - only attempts to add labels to node in 'To' DB where those labels are lacking in node with same key in 'From' DB. 

(Accidentally merged in some earlier work that was meant to be another branch.  No effect of these on unit tests.)