### PR TITLE
Update add_constraints_and_redundant_labels.py

### DIFF
--- a/src/uk/ac/ebi/vfb/neo4j/neo2neo/add_constraints_and_redundant_labels.py
+++ b/src/uk/ac/ebi/vfb/neo4j/neo2neo/add_constraints_and_redundant_labels.py
@@ -83,7 +83,7 @@ label_additions.append("MATCH (n:pub) WHERE NOT n:Individual SET n:Individual")
 
 label_additions.extend(["MATCH (a:Class)SET a:Entity", "MATCH (a:Individual)SET a:Entity"])  # Entity excludes Property. Not queried
 
-
+label_additions.extend("MATCH (n:Feature) SET n.self_xref = 'FlyBase'")
 
 nc.commit_list(label_additions)
 


### PR DESCRIPTION
Setting self_xrefs on Features.  Not adding for FBbt for now, as this won't work with self_xrefs - OBO-style ID needed for links.