### PR TITLE
Fix to accession generation supporting base36 and base10

### DIFF
--- a/src/uk/ac/ebi/vfb/neo4j/KB_tools.py
+++ b/src/uk/ac/ebi/vfb/neo4j/KB_tools.py
@@ -156,10 +156,8 @@ class iri_generator(kb_writer):
             results = results_2_dict_list(r)
             for res in results:
                 self.id_name[res['short_form']] = res['label']
-            if self.use_base36:
-                self.lookup = [base36.loads(int(x.split('_')[1])) for x in self.id_name.keys()]
-            else:
-                self.lookup = [int(x.split('_')[1]) for x in self.id_name.keys()]
+            self.lookup = [base36.loads(str(x.split('_')[1]))
+                           for x in self.id_name.keys()]  # This is slow and will not scale well!
             return True
         else:
             warnings.warn("No existing ids match the pattern %s_%s" % (idp, 'n'*acc_length))

--- a/src/uk/ac/ebi/vfb/neo4j/KB_tools.py
+++ b/src/uk/ac/ebi/vfb/neo4j/KB_tools.py
@@ -156,8 +156,8 @@ class iri_generator(kb_writer):
             results = results_2_dict_list(r)
             for res in results:
                 self.id_name[res['short_form']] = res['label']
-            self.lookup = [base36.loads(str(x.split('_')[1]))
-                           for x in self.id_name.keys()]  # This is slow and will not scale well!
+            self.lookup = {base36.loads(str(x.split('_')[1]))
+                           for x in self.id_name.keys()}  # This is slow and will not scale well!
             return True
         else:
             warnings.warn("No existing ids match the pattern %s_%s" % (idp, 'n'*acc_length))

--- a/src/uk/ac/ebi/vfb/neo4j/KB_tools.py
+++ b/src/uk/ac/ebi/vfb/neo4j/KB_tools.py
@@ -133,19 +133,21 @@ class iri_generator(kb_writer):
                  use_base36=False,
                  idp='VFB',
                  acc_length=8,
-                 base=map_iri('vfb')
-                 ):
+                 base=map_iri('vfb'),
+                 start=0):
         super().__init__(endpoint, usr, pwd)
         self.use_base36 = use_base36
         self._configure(idp=idp,
                         acc_length=acc_length,
                         base=base)
 
+
     def _configure(self, idp, acc_length, base):
         self.acc_length = acc_length
         self.idp = idp
         self.id_name = {}
         self.base = base
+        self.lookup = set()
         self.statements.append("MATCH (i:Individual) "
                                "WHERE i.short_form =~ '%s_[0-9a-z]{%d}' "  # Note POSIX regex rqd
                                "RETURN i.short_form as short_form, "
@@ -156,8 +158,15 @@ class iri_generator(kb_writer):
             results = results_2_dict_list(r)
             for res in results:
                 self.id_name[res['short_form']] = res['label']
-            self.lookup = {base36.loads(str(x.split('_')[1]))
-                           for x in self.id_name.keys()}  # This is slow and will not scale well!
+                acc = res['short_form'].split('_')[1]
+                # This does not scale well.  Better to roll lookup from some designated start?
+                if not self.use_base36:
+                    try:
+                        self.lookup.add(int(acc))
+                    except:
+                        self.lookup.add(base36.loads(acc))
+                else:
+                    self.lookup.add(base36.loads(acc))
             return True
         else:
             warnings.warn("No existing ids match the pattern %s_%s" % (idp, 'n'*acc_length))
@@ -180,8 +189,8 @@ class iri_generator(kb_writer):
             i = int(start)  # casting just in case
         while i in self.lookup:
             i += 1
-        self.lookup.append(i)
-        if base36:
+        self.lookup.add(i)
+        if self.use_base36:
             return base36.dumps(i)
         else:
             return i
@@ -984,7 +993,7 @@ class KB_pattern_writer(object):
                                          match_on='short_form',
                                          safe_label_edge=True)
 
-        return {dataset_id}
+        return dataset_id
 
 
 

--- a/src/uk/ac/ebi/vfb/neo4j/test/KB_tools_test.py
+++ b/src/uk/ac/ebi/vfb/neo4j/test/KB_tools_test.py
@@ -10,6 +10,7 @@ from ..KB_tools import kb_owl_edge_writer, node_importer, gen_id, iri_generator,
 from ...curie_tools import map_iri
 from ..neo4j_tools import results_2_dict_list, neo4j_connect
 import re
+import time
 
 def get_file_path(qualified_path):
     """Takes the fully qualified path of a file as the input.  Checks the current working directory.
@@ -197,21 +198,27 @@ class TestGenId(unittest.TestCase):
         assert r['short_form'] == 'HSNT_00000104'
         
 class TestIriGenerator(unittest.TestCase):
-    
-    def setUp(self):
-        self.ig = iri_generator('http://localhost:7474', 'neo4j', 'neo4j')
-        self.ig_b36 = iri_generator('http://localhost:7474', 'neo4j', 'neo4j', use_base36=True)
 
     def test_default_id_gen(self):
-        i = self.ig.generate(1)
+        start_time = time.time()
+        ig = iri_generator('http://localhost:7474', 'neo4j', 'neo4j')
+        print("iri_generator init time = " + str(time.time() - start_time))
+        start_time = time.time()
+        i = ig.generate(1)
+        print("ig_generate time = " + str(time.time()-start_time))
         print(i['short_form'])
         assert i['short_form'] == 'VFB_00000001'
 
     def test_base36_id_gen(self):
-        print(self.ig_b36.generate('9999'))
-        print(self.ig_b36.generate('9999'))
-        print(self.ig_b36.generate('jhm00000'))
-        print(self.ig_b36.generate('jhm00000'))
+        start_time = time.time()
+        ig_b36 = iri_generator('http://localhost:7474', 'neo4j', 'neo4j', use_base36=True)
+        print("b36_iri_generator init time = " + str(time.time() - start_time))
+        start_time = time.time()
+        print(ig_b36.generate('99999'))
+        print(ig_b36.generate('99999'))
+        print(ig_b36.generate('jhm00000'))
+        print(ig_b36.generate('jhm00000'))
+        print("b36_ig_generate time *4 = " + str(time.time()-start_time))
 
 
 class TestKBPatternWriter(unittest.TestCase):


### PR DESCRIPTION
Logic:
 * All accessions treated as if base36.
 * Accessions converted from base36 to base10 for incrementing
 * If base36 is True, new accession converted back to base36, if not remains as base10

Drawback  - rolling initial lookup is slow & scales badly.
Proposed solution:  Allow start to be specified during config... But how can start be used without converting everything?....
