### PR TITLE
miniref -> label

### DIFF
--- a/src/uk/ac/ebi/vfb/neo4j/flybase2neo/pub_tools.py
+++ b/src/uk/ac/ebi/vfb/neo4j/flybase2neo/pub_tools.py
@@ -29,8 +29,8 @@ class pubMover(FB2Neo):
             for k in d.keys():
                 if d[k] and not (k in ['fbrf', 'type']):
                     attribute_dict[k] = [d[k]]
-            if not d['title']:
-                print(attribute_dict)
+            if d['miniref']:
+                attribute_dict['label'] = d['miniref']
             self.ni.add_node(labels=['pub', 'Individual'],
                              IRI=map_iri('fb') + d['fbrf'],
                              attribute_dict=attribute_dict)


### PR DESCRIPTION
Looks like we never had a method to add minirefs as labels by default in the pubMover.  Added now.