### PR TITLE
Update expand_xrefs.py

### DIFF
--- a/src/uk/ac/ebi/vfb/neo4j/neo2neo/expand_xrefs.py
+++ b/src/uk/ac/ebi/vfb/neo4j/neo2neo/expand_xrefs.py
@@ -64,7 +64,7 @@ for d in dc:
                                     o=db,
                                     stype=':Entity',
                                     edge_annotations={
-                                        "accession": acc,
+                                        "accession": [acc],
                                     },
                                     match_on='short_form',
                                     safe_label_edge=True


### PR DESCRIPTION
Fixes `String("563")` is not a collection or a map