### PR TITLE
Api node xrefs

### DIFF
--- a/src/uk/ac/ebi/vfb/neo4j/KB_tools.py
+++ b/src/uk/ac/ebi/vfb/neo4j/KB_tools.py
@@ -354,14 +354,14 @@ class kb_owl_edge_writer(kb_writer):
                                match_on=match_on,
                                safe_label_edge=safe_label_edge)
 
-    def add_xref(self, s, xref, stype=''):
+    def add_xref(self, s, xref, otype=':Site', stype=''):
         """Add an xref axiom"""
         # Add regex test for xref
         x = xref.split(':')
         self.add_annotation_axiom(s=s,
                                   r='hasDbXref',
                                   o=x[0],
-                                  otype=':Site',
+                                  otype=otype,
                                   stype=stype,
                                   edge_annotations={'accession': x[1]},
                                   match_on='short_form',
@@ -874,6 +874,7 @@ class KB_pattern_writer(object):
                               anatomy_attributes=None,
                               dbxrefs=None,
                               dbxref_strings=None,
+                              dbxref_type=':Site',
                               image_filename='',
                               match_on='short_form',
                               orcid='',
@@ -894,6 +895,7 @@ class KB_pattern_writer(object):
         template: channel ID of the template to which the image is registered
         start: Start of range for generation of new accessions
         dbxrefs: dict of DB:accession pairs
+        dbxref_type: type of node for object of hasDbXref relationship, ':Site' by default.
         anatomy_attributes: Dict of property:value for anatomy node
 
         hard_fail: Boolean.  If True, throw exception for uknown entitise referenced in args"""
@@ -941,7 +943,7 @@ class KB_pattern_writer(object):
             for db, acc in dbxrefs.items():
                 self.ec.roll_dbxref_check(db, acc)
             if not self.ec.check(hard_fail=hard_fail):
-                warnings.warn("Load fail: Cross-referenced enties already exist.")
+                warnings.warn("Load fail: Cross-referenced entities already exist.")
                 return False
 
         if not self.ec.check(hard_fail=hard_fail):
@@ -978,7 +980,7 @@ class KB_pattern_writer(object):
                                              r='hasDbXref',
                                              o=db,
                                              stype=':Individual',
-                                             otype=':Individual:Site',
+                                             otype=':Individual' + dbxref_type,
                                              match_on='short_form',
                                              edge_annotations={'accession': acc},
                                              safe_label_edge=True

--- a/src/uk/ac/ebi/vfb/neo4j/KB_tools.py
+++ b/src/uk/ac/ebi/vfb/neo4j/KB_tools.py
@@ -976,15 +976,11 @@ class KB_pattern_writer(object):
 
         if dbxrefs:
             for db, acc in dbxrefs.items():
-                self.ew.add_annotation_axiom(s=anat_id['short_form'],
-                                             r='hasDbXref',
-                                             o=db,
-                                             stype=':Individual',
-                                             otype=':Individual' + dbxref_type,
-                                             match_on='short_form',
-                                             edge_annotations={'accession': acc},
-                                             safe_label_edge=True
-                                             )
+                self.ew.add_xref(s=anat_id['short_form'],
+                                 xref=':'.join([db, acc]),
+                                 stype=':Individual',
+                                 otype=':Individual' + dbxref_type,
+                                 )
         if orcid:
             self.ew.add_annotation_axiom(s=anat_id['short_form'],
                                          r='contributor',


### PR DESCRIPTION
fixes #236 
I think this [roll_entity_check](https://github.com/VirtualFlyBrain/VFB_neo4j/blob/master/src/uk/ac/ebi/vfb/neo4j/KB_tools.py#L923) should be complaining when I set ```dbxrefs={'jrc_slide_code_api':'00001'}```, but it isn't.
The only error was when committing, but this is now fixed when setting ```dbxref_type=':API'```