### PR TITLE
base36 ID generator profanity implementation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pandasql
 pysolr
 base36
 vfb_connect
+better_profanity

--- a/src/uk/ac/ebi/vfb/neo4j/KB_tools.py
+++ b/src/uk/ac/ebi/vfb/neo4j/KB_tools.py
@@ -66,20 +66,23 @@ def gen_id(idp, ID, length, id_name, use_base36=False):
     return {'short_form': k, 'acc_int': ID}  # useful to return ID to use for next round.
 
 
-def contains_profanity(value):
+def contains_profanity(value, use_base36):
     """
     Checks if the input text has any swear words.
     Parameters:
         value: phrase to check
+        use_base36: boolean variable to enable/disable base36 validation
     Return:
         True the input text has any swear words, False otherwise.
     """
-    min_length = 3
-    max_length = len(value)
+    if use_base36:
+        min_length = 3
+        max_length = len(value)
 
-    all_substrings = [value[i:i + j] for i in range(len(value) - min_length) for j in
-                      range(min_length, max_length + 1)]
-    return profanity.contains_profanity(" ".join(all_substrings))
+        all_substrings = [value[i:i + j] for i in range(len(value) - min_length) for j in
+                          range(min_length, max_length + 1)]
+        return profanity.contains_profanity(" ".join(all_substrings))
+    return False
 
 
 
@@ -199,7 +202,7 @@ class iri_generator(kb_writer):
             i = base36.loads(start)
         else:
             i = int(start)  # casting just in case
-        while i in self.lookup or contains_profanity(base36.dumps(i)):
+        while i in self.lookup or contains_profanity(base36.dumps(i), self.use_base36):
             i += 1
         self.lookup.add(i)
         if self.use_base36:

--- a/src/uk/ac/ebi/vfb/neo4j/KB_tools.py
+++ b/src/uk/ac/ebi/vfb/neo4j/KB_tools.py
@@ -12,6 +12,7 @@ from .neo4j_tools import neo4j_connect, results_2_dict_list
 from .SQL_tools import get_fb_conn, dict_cursor
 from ..curie_tools import map_iri
 import base36
+from better_profanity import profanity
 
 
 #  * OWL - Only edges of types Related, INSTANCEOF, SUBCLASSOF are exported to OWL.
@@ -65,6 +66,20 @@ def gen_id(idp, ID, length, id_name, use_base36=False):
     return {'short_form': k, 'acc_int': ID}  # useful to return ID to use for next round.
 
 
+def contains_profanity(value):
+    """
+    Checks if the input text has any swear words.
+    Parameters:
+        value: phrase to check
+    Return:
+        True the input text has any swear words, False otherwise.
+    """
+    min_length = 3
+    max_length = len(value)
+
+    all_substrings = [value[i:i + j] for i in range(len(value) - min_length) for j in
+                      range(min_length, max_length + 1)]
+    return profanity.contains_profanity(" ".join(all_substrings))
 
 
 
@@ -184,7 +199,7 @@ class iri_generator(kb_writer):
             i = base36.loads(start)
         else:
             i = int(start)  # casting just in case
-        while i in self.lookup:
+        while i in self.lookup or contains_profanity(base36.dumps(i)):
             i += 1
         self.lookup.add(i)
         if self.use_base36:

--- a/src/uk/ac/ebi/vfb/neo4j/KB_tools.py
+++ b/src/uk/ac/ebi/vfb/neo4j/KB_tools.py
@@ -73,7 +73,7 @@ def contains_profanity(value, use_base36):
         value: phrase to check
         use_base36: boolean variable to enable/disable base36 validation
     Return:
-        True the input text has any swear words, False otherwise.
+        True if the input text has any swear words, False otherwise.
     """
     if use_base36:
         min_length = 3

--- a/src/uk/ac/ebi/vfb/neo4j/test/KB_tools_test.py
+++ b/src/uk/ac/ebi/vfb/neo4j/test/KB_tools_test.py
@@ -259,14 +259,14 @@ class TestIriGenerator(unittest.TestCase):
         print("b36_ig_generate time *4 = " + str(time.time()-start_time))
 
     def test_profanity_checker(self):
-        assert contains_profanity("11fuck02") is True
-        assert contains_profanity("1h4ndjob") is True
-        assert contains_profanity("3h4ndj0b") is True
-        assert contains_profanity("1usuck43") is True
-        assert contains_profanity("141aassd") is True
+        assert contains_profanity("11fuck02", True) is True
+        assert contains_profanity("1h4ndjob", True) is True
+        assert contains_profanity("3h4ndj0b", True) is True
+        assert contains_profanity("1usuck43", True) is True
+        assert contains_profanity("141aassd", True) is True
 
-        assert contains_profanity("e234dsd1") is False
-        assert contains_profanity("e2none31") is False
+        assert contains_profanity("e234dsd1", True) is False
+        assert contains_profanity("e2none31", True) is False
 
 class TestKBPatternWriter(unittest.TestCase):
 

--- a/src/uk/ac/ebi/vfb/neo4j/test/KB_tools_test.py
+++ b/src/uk/ac/ebi/vfb/neo4j/test/KB_tools_test.py
@@ -6,7 +6,7 @@ Created on Mar 8, 2017
 import unittest
 import os
 
-from ..KB_tools import kb_owl_edge_writer, node_importer, gen_id, iri_generator, KB_pattern_writer, EntityChecker
+from ..KB_tools import kb_owl_edge_writer, node_importer, gen_id, iri_generator, KB_pattern_writer, EntityChecker, contains_profanity
 from ...curie_tools import map_iri
 from ..neo4j_tools import results_2_dict_list, neo4j_connect
 import re
@@ -246,6 +246,27 @@ class TestIriGenerator(unittest.TestCase):
         print(ig_b36.generate('jhm00000'))
         print("b36_ig_generate time *4 = " + str(time.time()-start_time))
 
+    def test_base36_id_gen_profanity(self):
+        start_time = time.time()
+        ig_b36 = iri_generator('http://localhost:7474', 'neo4j', 'test', use_base36=True)
+        print("b36_iri_generator init time = " + str(time.time() - start_time))
+        start_time = time.time()
+
+        assert ig_b36.generate('fucj')["short_form"] == 'VFB_0000fucj'
+        assert ig_b36.generate('fucj')["short_form"] == 'VFB_0000fucl'
+        assert ig_b36.generate('fucj')["short_form"] == 'VFB_0000fucm'
+        assert ig_b36.generate('fucj')["short_form"] == 'VFB_0000fucn'
+        print("b36_ig_generate time *4 = " + str(time.time()-start_time))
+
+    def test_profanity_checker(self):
+        assert contains_profanity("11fuck02") is True
+        assert contains_profanity("1h4ndjob") is True
+        assert contains_profanity("3h4ndj0b") is True
+        assert contains_profanity("1usuck43") is True
+        assert contains_profanity("141aassd") is True
+
+        assert contains_profanity("e234dsd1") is False
+        assert contains_profanity("e2none31") is False
 
 class TestKBPatternWriter(unittest.TestCase):
 


### PR DESCRIPTION
Related with issue #204

Used: [better-profanity](https://pypi.org/project/better-profanity/). id generation time increased from 0.0002 to 0.0050

Tried: [profanity](https://pypi.org/project/profanity/). id generation time increased from 0.0002 to 0.0032 but accuracy was not good enough, missed many bad words

Tried: [profanity-check](https://pypi.org/project/profanity-check/) scikit library dependency related issues occurred. Too heavy weight for our needs. 